### PR TITLE
src/window.h: Fix FTBFS on GCC 15

### DIFF
--- a/src/window.h
+++ b/src/window.h
@@ -2,6 +2,7 @@
 #define WINDOW_H
 
 #include "window_type.h"
+#include <cstdint>
 #include <vector>
 #include <memory>
 #include <string>


### PR DESCRIPTION
Using `uint32_t` requires importing `cstdint`.

```
In file included from src/main_window.h:4,
                 from src/main.cpp:1:
src/window.h:22:24: error: 'uint32_t' does not name a type
   22 |                 static uint32_t id_counter;
      |                        ^~~~~~~~
src/window.h:8:1: note: 'uint32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
    7 | #include <string>
  +++ |+#include <cstdint>
    8 | 
src/window.h:25:17: error: 'uint32_t' does not name a type
   25 |                 uint32_t id;
      |                 ^~~~~~~~
src/window.h:25:17: note: 'uint32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
```